### PR TITLE
rename dist min and max to traversal_number

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
         "Sugiyama",
         "Tagawa",
         "Toda",
+        "trav",
         "unscanned",
         "unsearched",
         "vertice",

--- a/src/graph/network_simplex.rs
+++ b/src/graph/network_simplex.rs
@@ -143,7 +143,7 @@ impl Graph {
                     self.get_node(src_idx).spanning_tree(),
                     self.get_node(dst_idx).spanning_tree(),
                 ) {
-                    if src_tree.tree_dist_max() < dst_tree.tree_dist_max() {
+                    if src_tree.traversal_number() < dst_tree.traversal_number() {
                         (src_idx, delta)
                     } else {
                         (dst_idx, -delta)
@@ -339,15 +339,23 @@ impl Graph {
         let (disposition, search_node_idx, min, max) = {
             let src_node = self.get_node(edge.src_node);
             let dst_node = self.get_node(edge.dst_node);
-            let src_node_max = src_node.tree_dist_max().expect("must have subtree_max");
-            let dst_node_max = dst_node.tree_dist_max().expect("must have subtree_max");
+            let src_node_max = src_node
+                .tree_traversal_number()
+                .expect("must have traversal_number");
+            let dst_node_max = dst_node
+                .tree_traversal_number()
+                .expect("must have traversal_number");
 
             if src_node_max < dst_node_max {
-                let src_node_min = src_node.tree_dist_min().expect("must have subtree_min");
+                let src_node_min = src_node
+                    .tree_descendent_min_traversal_number()
+                    .expect("must have min_traversal");
 
                 (In, edge.src_node, src_node_min, src_node_max)
             } else {
-                let dst_node_min = dst_node.tree_dist_min().expect("must have subtree_min");
+                let dst_node_min = dst_node
+                    .tree_descendent_min_traversal_number()
+                    .expect("must have min_traversal");
 
                 (Out, edge.dst_node, dst_node_min, dst_node_max)
             }
@@ -390,40 +398,60 @@ impl Graph {
         let mut candidate_edge_idx = candidate_edge_idx;
         let search_node = self.get_node(search_node_idx);
         let search_node_tree_dist_max = search_node
-            .tree_dist_max()
+            .tree_traversal_number()
             .expect("Search node must have dist_max set");
 
         // println!(
         //     "   select_edge_for_simplex: SEARCH_NODE: {}",
         //     self.node_to_string(search_node_idx)
         // );
-        for edge_idx in search_node.get_edges(disposition).iter().cloned() {
-            let edge = self.get_edge(edge_idx);
+
+        // Recursively all the edges of the search_node for a candidate edge
+        // that are farther away from the root of the tree.
+        for (edge_idx, edge_disposition) in
+            search_node.get_all_edges_with_disposition(disposition == Out)
+        {
+            let edge = self.get_edge(*edge_idx);
             if edge.ignored {
                 continue;
             }
-            let node_idx = match disposition {
-                In => edge.src_node,
-                Out => edge.dst_node,
+            let disposition_match = disposition == edge_disposition;
+            // Select the node on the other side on this edge (based on which way we are looking)
+            let node_idx = if disposition_match {
+                match disposition {
+                    In => edge.src_node,
+                    Out => edge.dst_node,
+                }
+            } else {
+                match disposition.opposite() {
+                    In => edge.src_node,
+                    Out => edge.dst_node,
+                }
             };
             let node_tree_dist_max = self
                 .get_node(node_idx)
-                .tree_dist_max()
+                .tree_traversal_number()
                 .expect("Candidate node must have a subtree");
             // println!(
             //     "   select_edge_for_simplex: checking '{disposition}' edge: {}",
             //     self.edge_to_string(edge_idx)
             // );
 
-            if !edge.in_spanning_tree() {
-                let slack = self.simplex_slack(edge_idx).expect("Edge must have slack");
+            if !edge.in_spanning_tree() && !disposition_match {
+                // If the edge is not in the spanning tree, and it does not point in the direction
+                // that we are searching, skip it: it connects to the wrong side of the tree.
+            } else if !edge.in_spanning_tree() {
+                // If the edge not in the spanning tree, but is pointing in the direction we
+                // are searching, we may have a candidate edge.  If is on the correct side of the
+                // tree, selected it if it has smallest slack of any candidate so far.
+                let slack = self.simplex_slack(*edge_idx).expect("Edge must have slack");
                 let candidate_slack = candidate_edge_idx
                     .map(|edge_idx| self.simplex_slack(edge_idx).expect("edge must have slack"));
 
                 if !self.node_in_tail_component(node_idx, min, max)
                     && (candidate_slack.is_none() || Some(slack) < candidate_slack)
                 {
-                    candidate_edge_idx = Some(edge_idx);
+                    candidate_edge_idx = Some(*edge_idx);
                     // println!(
                     //     "   selected: {edge_idx} because: !({min} <= {} <= {max}) and: Some({slack}) < {:?}: {}",
                     //     self.get_node(node_idx)
@@ -450,43 +478,6 @@ impl Graph {
                 //     "   select_edge_for_simplex: rejected edge: {}",
                 //     self.edge_to_string(edge_idx)
                 // );
-            }
-        }
-
-        // println!("   select_edge_for_simplex: next phase");
-        for edge_idx in self
-            .node_tree_edges(search_node_idx, disposition.opposite())
-            .iter()
-            .cloned()
-        {
-            // println!(
-            //     "   select_edge_for_simplex: checking edge {}: {}",
-            //     disposition.opposite(),
-            //     self.edge_to_string(edge_idx)
-            // );
-            let edge = self.get_edge(edge_idx);
-            if edge.ignored {
-                continue;
-            }
-            let node_idx = match disposition.opposite() {
-                In => edge.src_node,
-                Out => edge.dst_node,
-            };
-            let node_tree_dist_max = self
-                .get_node(node_idx)
-                .tree_dist_max()
-                .expect("Candidate node must have a dist_max");
-
-            if node_tree_dist_max < search_node_tree_dist_max {
-                candidate_edge_idx = self.select_edge_for_simplex(
-                    disposition,
-                    node_idx,
-                    min,
-                    max,
-                    candidate_edge_idx,
-                );
-            } else {
-                // println!("   select_edge_for_simplex: rejected edge {edge_idx}: {node_tree_dist_max} < {search_node_tree_dist_max}");
             }
         }
 
@@ -616,9 +607,10 @@ impl Graph {
                         let src_node = self.get_node(tree_edge.src_node);
                         let dst_node = self.get_node(tree_edge.dst_node);
 
-                        if let (Some(src_dist_max), Some(dst_dist_max)) =
-                            (src_node.tree_dist_max(), dst_node.tree_dist_max())
-                        {
+                        if let (Some(src_dist_max), Some(dst_dist_max)) = (
+                            src_node.tree_traversal_number(),
+                            dst_node.tree_traversal_number(),
+                        ) {
                             let (rerank_node_idx, delta) = if src_dist_max < dst_dist_max {
                                 (tree_edge.src_node, non_tree_edge_slack / 2)
                             } else {

--- a/src/graph/network_simplex/cutvalue.rs
+++ b/src/graph/network_simplex/cutvalue.rs
@@ -61,8 +61,8 @@ impl Graph {
 
         let lca = self.get_node(lca_idx);
         let lca_min = lca
-            .tree_dist_min()
-            .expect("lca does not have a sub_tree_idx_min");
+            .tree_descendent_min_traversal_number()
+            .expect("lca does not have a min_traversal_number");
 
         self.invalidate_path_to_lca(lca_idx, sel_dst_node_idx);
         self.invalidate_path_to_lca(lca_idx, sel_src_node_idx);
@@ -146,11 +146,11 @@ impl Graph {
         let parent_edge = self.get_edge(parent_edge_idx);
         let parent_src_dist_max = self
             .get_node(parent_edge.src_node)
-            .tree_dist_max()
+            .tree_traversal_number()
             .expect("tree_dist_max not set");
         let parent_dst_dist_max = self
             .get_node(parent_edge.dst_node)
-            .tree_dist_max()
+            .tree_traversal_number()
             .expect("tree_dist_max not set");
 
         (parent_src_dist_max, parent_dst_dist_max)

--- a/src/graph/network_simplex/spanning_tree.rs
+++ b/src/graph/network_simplex/spanning_tree.rs
@@ -52,14 +52,14 @@ impl Graph {
         child_idx: usize,
     ) -> bool {
         let maybe_ancestor_node = self.get_node(maybe_ancestor_node_idx);
-        let ancestor_dist_min = maybe_ancestor_node
-            .tree_dist_min()
+        let descendent_min_traversal = maybe_ancestor_node
+            .tree_descendent_min_traversal_number()
             .expect("tree distance must be set");
-        let ancestor_dist_max = maybe_ancestor_node
-            .tree_dist_max()
+        let traversal_number = maybe_ancestor_node
+            .tree_traversal_number()
             .expect("tree distance must be set");
 
-        self.node_in_tail_component(child_idx, ancestor_dist_min, ancestor_dist_max)
+        self.node_in_tail_component(child_idx, descendent_min_traversal, traversal_number)
     }
 
     /// Return true if node_idx is in the tail component the node that holds min and max.
@@ -79,21 +79,21 @@ impl Graph {
     /// edge parent(v) by which the node was reached (see figure 2-5).
     ///
     /// This provides an inexpensive way to test whether a node lies in the head or tail component of a tree edge,
-    /// and thus whether a non-tree edge crosses between the two components.  For example, if e = (u ,v) is a tree
+    /// and thus whether a non-tree edge crosses between the two components.  For example, if e = (u, v) is a tree
     /// edge and v root is in the head component of the edge (i.e., lim(u) < lim(v)), then a node w is in the tail
     /// component of e if and only if low(u) ≤ lim(w) ≤ lim(u).  These numbers can also be used to update the
-    /// tree efficiently during the network simplex iterations.  If f = (w ,x) is the entering edge, the only edges
+    /// tree efficiently during the network simplex iterations.  If f = (w, x) is the entering edge, the only edges
     /// whose cut values must be adjusted are those in the path connecting w and x in the tree.  This path is determined
     /// by following the parent edges back from w and x until the least common ancestor is reached, i.e., the first node
     /// l such that low(l) ≤ lim(w) , lim(x) ≤ lim(l).  Of course, these postorder parameters must also be adjusted
     /// when exchanging tree edges, but only for nodes below l.
-    pub(super) fn node_in_tail_component(&self, node_idx: usize, min: usize, max: usize) -> bool {
-        let tree_dist_max = self
+    pub(super) fn node_in_tail_component(&self, node_idx: usize, descendent_min_traversal: usize, max_traversal_number: usize) -> bool {
+        let node_traversal_number = self
             .get_node(node_idx)
-            .tree_dist_max()
+            .tree_traversal_number()
             .expect("tree_dist_max must be set");
 
-        min <= tree_dist_max && tree_dist_max <= max
+        descendent_min_traversal <= node_traversal_number && node_traversal_number <= max_traversal_number
     }
 
     /// Sets a feasible tree within the given graph by setting feasible_tree_member on tree member nodes.
@@ -250,7 +250,7 @@ impl Graph {
         initializing: bool,
         node_idx: usize,
         parent_edge_idx: Option<usize>,
-        min: usize,
+        min_traversal_number: usize,
     ) -> usize {
         let node = self.get_node(node_idx);
 
@@ -272,36 +272,36 @@ impl Graph {
             //   * when the path is invalidated, tree_dst_min is set to: None
             if let Some(tree_data) = node.spanning_tree() {
                 if tree_data.edge_idx_to_parent() == parent_edge_idx
-                    && tree_data.tree_dist_min() == Some(min)
+                    && tree_data.descendent_min_traversal_number() == Some(min_traversal_number)
                 {
-                    return tree_data.tree_dist_max().unwrap_or(0) + 1;
+                    return tree_data.traversal_number().unwrap_or(0) + 1;
                 }
             } else {
                 panic!("Setting tree ranges on a node that is not in the tree!");
             }
         }
 
-        let cur_max = node.tree_dist_max();
+        let cur_max_traversal_number = node.tree_traversal_number();
         self.get_node_mut(node_idx)
-            .set_tree_data(parent_edge_idx, Some(min), cur_max);
+            .set_tree_data(parent_edge_idx, Some(min_traversal_number), cur_max_traversal_number);
 
-        let mut max = min;
-
+        let mut max_traversal_number = min_traversal_number;
         for (node_idx, edge_idx) in self.non_parent_tree_nodes(node_idx) {
-            max = max.max(self.set_tree_parents_and_ranges(
+            max_traversal_number = max_traversal_number.max(self.set_tree_parents_and_ranges(
                 initializing,
                 node_idx,
                 Some(edge_idx),
-                max,
+                max_traversal_number,
             ));
         }
 
-        self.get_node_mut(node_idx).set_tree_dist_max(Some(max));
+        self.get_node_mut(node_idx)
+            .set_tree_traversal_number(Some(max_traversal_number));
 
-        if max > self.node_count() {
+        if max_traversal_number > self.node_count() {
             panic!("set_tree_parents_and_ranges must be looping!")
         }
-        max + 1
+        max_traversal_number + 1
     }
 
     /// Set tree_dist_min=None for all nodes from from_node up to and including lca_node.
@@ -325,15 +325,15 @@ impl Graph {
         loop {
             let from_node = self.get_node(from_node_idx);
 
-            if from_node.tree_dist_min().is_none() {
+            if from_node.tree_descendent_min_traversal_number().is_none() {
                 break;
             }
 
-            // We are "invalidating" the node buy setting the tree_dst_min to None
-            from_node.set_tree_dist_min(None);
+            // We are "invalidating" the node buy setting the tree_descendent_min to None
+            from_node.set_tree_descendent_min(None);
 
             if let Some(parent_edge_idx) = from_node.spanning_tree_parent_edge_idx() {
-                if from_node.tree_dist_max() >= lca_node.tree_dist_max() {
+                if from_node.tree_traversal_number() >= lca_node.tree_traversal_number() {
                     if from_node_idx != lca_node_idx {
                         panic!("invalidate_path: skipped over LCA");
                     }
@@ -344,11 +344,12 @@ impl Graph {
                 let parent_src = self.get_node(parent_edge.src_node);
                 let parent_dst = self.get_node(parent_edge.dst_node);
 
-                from_node_idx = if parent_src.tree_dist_max() > parent_dst.tree_dist_max() {
-                    parent_edge.src_node
-                } else {
-                    parent_edge.dst_node
-                };
+                from_node_idx =
+                    if parent_src.tree_traversal_number() > parent_dst.tree_traversal_number() {
+                        parent_edge.src_node
+                    } else {
+                        parent_edge.dst_node
+                    };
             } else {
                 break;
             }
@@ -480,7 +481,9 @@ impl Graph {
         }
 
         let search_sub_tree_root = self.find_node_sub_tree_root(search_node_idx);
-        println!("tightest_incident_edge_search: {search_node_idx} sub_tree:{search_sub_tree_root:?}");
+        println!(
+            "tightest_incident_edge_search: {search_node_idx} sub_tree:{search_sub_tree_root:?}"
+        );
         for (edge_idx, next_node_idx) in
             self.get_node_edges_and_adjacent_node(search_node_idx, true)
         {
@@ -759,8 +762,9 @@ impl Graph {
                     r#"{} [label="{} ({}, {})"]; "#,
                     node.name,
                     node.name,
-                    node.tree_dist_min().unwrap_or_default(),
-                    node.tree_dist_max().unwrap_or_default()
+                    node.tree_descendent_min_traversal_number()
+                        .unwrap_or_default(),
+                    node.tree_traversal_number().unwrap_or_default()
                 )
             }
             self.print_tree_helper(root_idx);

--- a/src/graph/network_simplex/spanning_tree.rs
+++ b/src/graph/network_simplex/spanning_tree.rs
@@ -260,7 +260,7 @@ impl Graph {
             "None".to_string()
         };
         println!(
-            "set_tree_parents_and_ranges('{}', {parent_edge_idx:?}, {min})\n  cur_node: {}\n  parent_edge:{par_str}",
+            "set_tree_parents_and_ranges('{}', {parent_edge_idx:?}, {min_traversal_number})\n  cur_node: {}\n  parent_edge:{par_str}",
             node.name,
             self.node_to_string(node_idx),
         );


### PR DESCRIPTION
I finally clarified from the original paper what the tree_min and tree_max were: based on the traversal number assigned.  Switched the field names to account for this-- should greatly increase clarity.

Also, simplified select_edge_for_simplex() to use a single loop for all edges, instead of doing basically the same loop twice.