### PR TITLE
KNO-14: Disable snaphots by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ This is not production quality because:
 * Does not implement subgraphs, nor most other exotic options
   in dot files.
 * Draws straight lines for edges, not splines.
-* Runs quite a bit slower, but this can likely be easily fixed
-  with some investigation.
   
 Some side by size comparison examples:
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
 //! Top level api methods for dot-rs.
 
-use crate::{graph::{Graph, Snapshots}, svg::{SvgStyle, SVG}};
+use crate::{graph::{snapshot::Snapshots, Graph}, svg::{SvgStyle, SVG}};
 
 /// Given a valid dot string, return an svg string.
 /// 

--- a/src/api.rs
+++ b/src/api.rs
@@ -21,6 +21,7 @@ pub fn dot_to_svg(dot: &str) -> String {
 pub fn dot_to_svg_debug_snapshots(dot: &str) -> Snapshots {
     let mut graph = Graph::from(dot);
     
+    graph.enable_snapshots();
     graph.layout_nodes();
     graph.get_debug_svg_snapshots()
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -9,6 +9,7 @@ mod edge;
 mod network_simplex;
 pub mod node;
 mod rank_orderings;
+pub mod snapshot;
 
 use rank_orderings::RankOrderings;
 use std::{
@@ -28,7 +29,7 @@ use self::{
     },
     network_simplex::SimplexNodeTarget::{VerticalRank, XCoordinate},
     node::{Node, NodeType, Point, Rect, NODE_MIN_SEP_X, NODE_START_HEIGHT},
-    rank_orderings::AdjacentRank,
+    rank_orderings::AdjacentRank, snapshot::Snapshots,
 };
 
 /// Simplest possible representation of a graph until more is needed.
@@ -65,80 +66,6 @@ pub struct Graph {
     snapshots_enabled: bool,
     /// Attributes for nodes.  For example, label="my_node_label"
     node_attr: HashMap<String, HashMap<String, String>>,
-}
-
-type SnapShotVec = Vec<(String, String)>;
-
-#[derive(Debug, Clone, Default)]
-pub struct Snapshots {
-    total: usize,
-    groups: Vec<(String, SnapShotVec)>,
-}
-
-impl Snapshots {
-    fn new() -> Snapshots {
-        Snapshots {
-            total: 0,
-            groups: Vec::new(),
-        }
-    }
-
-    /// Add a new group to save snapshots to.
-    ///
-    /// New snapshots can only be added to the current group
-    pub fn new_group(&mut self, group_title: &str) {
-        self.groups.push((group_title.to_string(), Vec::new()));
-    }
-
-    /// Add a new snapshot to the current group.
-    pub fn add(&mut self, title: &str, snap: &str) {
-        if let Some(last) = self.groups.last_mut() {
-            last.1.push((title.to_string(), snap.to_string()));
-        } else {
-            panic!("No snapshot group set!")
-        }
-        self.total += 1;
-    }
-
-    pub fn get(&self, frame: usize) -> Option<(String, String, String)> {
-        let mut cur_frame = 0_usize;
-        for (title, group) in self.groups.iter() {
-            if cur_frame + group.len() > frame {
-                let index = frame - cur_frame;
-                let snapshot = group.get(index).expect("element not present");
-
-                return Some((title.clone(), snapshot.0.clone(), snapshot.1.clone()));
-            }
-            cur_frame += group.len();
-        }
-        None
-    }
-
-    pub fn group_count(&self) -> usize {
-        self.groups.len()
-    }
-
-    pub fn total_count(&self) -> usize {
-        self.total
-    }
-
-    pub fn steps(&self, frame: usize) -> (usize, usize) {
-        let mut cur_frame = 0_usize;
-        let mut prev_frame = 0_usize;
-        for (_title, group) in self.groups.iter() {
-            if cur_frame + group.len() > frame {
-                let start_frame = if frame == cur_frame {
-                    prev_frame
-                } else {
-                    cur_frame
-                };
-                return (start_frame, cur_frame + group.len());
-            }
-            prev_frame = cur_frame;
-            cur_frame += group.len();
-        }
-        (0, self.total_count())
-    }
 }
 
 impl Default for Graph {

--- a/src/graph/snapshot.rs
+++ b/src/graph/snapshot.rs
@@ -1,0 +1,79 @@
+
+
+//! Snapshots for graphs: used for debugging
+//!
+//! Saves an SVG of the graph during various points in layout.
+
+type SnapShotVec = Vec<(String, String)>;
+
+#[derive(Debug, Clone, Default)]
+pub struct Snapshots {
+    total: usize,
+    groups: Vec<(String, SnapShotVec)>,
+}
+
+impl Snapshots {
+    pub fn new() -> Snapshots {
+        Snapshots {
+            total: 0,
+            groups: Vec::new(),
+        }
+    }
+
+    /// Add a new group to save snapshots to.
+    ///
+    /// New snapshots can only be added to the current group
+    pub fn new_group(&mut self, group_title: &str) {
+        self.groups.push((group_title.to_string(), Vec::new()));
+    }
+
+    /// Add a new snapshot to the current group.
+    pub fn add(&mut self, title: &str, snap: &str) {
+        if let Some(last) = self.groups.last_mut() {
+            last.1.push((title.to_string(), snap.to_string()));
+        } else {
+            panic!("No snapshot group set!")
+        }
+        self.total += 1;
+    }
+
+    pub fn get(&self, frame: usize) -> Option<(String, String, String)> {
+        let mut cur_frame = 0_usize;
+        for (title, group) in self.groups.iter() {
+            if cur_frame + group.len() > frame {
+                let index = frame - cur_frame;
+                let snapshot = group.get(index).expect("element not present");
+
+                return Some((title.clone(), snapshot.0.clone(), snapshot.1.clone()));
+            }
+            cur_frame += group.len();
+        }
+        None
+    }
+
+    pub fn group_count(&self) -> usize {
+        self.groups.len()
+    }
+
+    pub fn total_count(&self) -> usize {
+        self.total
+    }
+
+    pub fn steps(&self, frame: usize) -> (usize, usize) {
+        let mut cur_frame = 0_usize;
+        let mut prev_frame = 0_usize;
+        for (_title, group) in self.groups.iter() {
+            if cur_frame + group.len() > frame {
+                let start_frame = if frame == cur_frame {
+                    prev_frame
+                } else {
+                    cur_frame
+                };
+                return (start_frame, cur_frame + group.len());
+            }
+            prev_frame = cur_frame;
+            cur_frame += group.len();
+        }
+        (0, self.total_count())
+    }
+}

--- a/tests/dot_to_svg.rs
+++ b/tests/dot_to_svg.rs
@@ -15,6 +15,7 @@ fn write_svg_to_example_file(test_title: &str, svg: &str) {
     file.write_all(svg.as_bytes()).unwrap();
 }
 
+#[allow(unused)]
 fn write_graphviz_svg_example(test_title: &str, dot_str: &str) {
     let graphviz_svg_file_path = get_svg_example_path(test_title, SvgGenerator::GraphViz);
 
@@ -35,7 +36,7 @@ fn system_call_dot_to_svg_file(dot_str: &str, svg_path: &str) {
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn();
-    
+
     if let Ok(mut dot_child) = result {
         let mut stdin = dot_child.stdin.take().expect("Failed to open stdin");
         std::thread::spawn(move || {
@@ -81,5 +82,7 @@ fn test_dot_to_svg(test_title: &str) {
     let svg = dot_to_svg(&dot);
 
     write_svg_to_example_file(test_title, &svg);
-    write_graphviz_svg_example(test_title, &dot)
+
+    // Only enable if you want to re-generate GraphViz examples.
+    // write_graphviz_svg_example(test_title, &dot)
 }


### PR DESCRIPTION
Snapshots were slowing down large graphs by something like 30x.

* Only enable snapshots when explicitly asked
* Move snapshots to it's own files
* For integration tests, only create a GraphViz version if you uncomment